### PR TITLE
feat: add tab audio mixing and webcam overlay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,43 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+A Chrome extension that records screen and audio locally, outputting WebM video files. It's a free, privacy-focused alternative to services like Loom - all recording happens client-side with no cloud upload.
+
+## Commands
+
+```bash
+pnpm install     # Install dependencies
+pnpm dev         # Start Vite dev server on port 5173
+pnpm build       # Build for production (outputs to dist/)
+```
+
+After building, load the `dist` folder as an unpacked Chrome extension.
+
+## Architecture
+
+- **React + TypeScript + Vite** frontend with TailwindCSS styling
+- **Chrome Extension (Manifest V3)** - the built app runs as a browser extension
+- Uses `navigator.mediaDevices.getDisplayMedia()` for screen capture and `getUserMedia()` for microphone
+
+### Key Files
+
+- `src/recorder.ts` - Core recording logic using MediaRecorder API; handles mic/screen/audio streams and WebM output
+- `src/App.tsx` - Main UI component with recording controls and options (mic/audio toggles)
+- `public/manifest.json` - Chrome extension manifest
+- `public/background.js` - Extension service worker
+
+### Data Flow
+
+1. User selects recording options (mic, computer audio, screen)
+2. `startRecording()` acquires media streams and creates a `MediaRecorder`
+3. Recording chunks are collected via `ondataavailable`
+4. On stop, blobs are combined and downloaded as a timestamped `.webm` file
+
+### Libraries
+
+- `react-hook-form` - Form state for recording options
+- `ts-pattern` - Pattern matching for UI state
+- `use-local-storage-state` - Persists user preferences

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ export const App = () => {
         enableMic: true,
         enableAudio: true,
         enableScreen: true,
+        enableCamera: false,
       },
     },
   )
@@ -62,6 +63,10 @@ export const App = () => {
             <label className="flex justify-between items-center">
               Enable Screen
               <input type="checkbox" disabled {...register('enableScreen')} />
+            </label>
+            <label className="flex justify-between items-center">
+              Enable Camera
+              <input type="checkbox" {...register('enableCamera')} />
             </label>
           </div>
           <div className="">

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -5,24 +5,54 @@ export interface StartRecordingOption {
 }
 
 export async function startRecording(option: StartRecordingOption) {
-  const tracks: MediaStreamTrack[] = []
-
-  if (option.enableMic) {
-    try {
-      const micTrack = await navigator.mediaDevices.getUserMedia({
-        audio: true,
-      })
-      tracks.push(...micTrack.getTracks())
-    } catch (e) {
-      console.error('could not get audio source: ', e)
-    }
-  }
-
   const screen = await navigator.mediaDevices.getDisplayMedia({
     audio: option.enableAudio,
     video: option.enableScreen,
   })
-  tracks.push(...screen.getTracks())
+
+  const tracks: MediaStreamTrack[] = []
+  const audioSources: MediaStream[] = []
+
+  // Collect video track
+  const videoTrack = screen.getVideoTracks()[0]
+  if (videoTrack) {
+    tracks.push(videoTrack)
+  }
+
+  // Collect tab/system audio
+  const tabAudioTrack = screen.getAudioTracks()[0]
+  if (tabAudioTrack) {
+    audioSources.push(new MediaStream([tabAudioTrack]))
+  }
+
+  // Collect mic audio
+  if (option.enableMic) {
+    try {
+      const micStream = await navigator.mediaDevices.getUserMedia({
+        audio: true,
+      })
+      audioSources.push(micStream)
+    } catch (e) {
+      console.error('could not get mic audio: ', e)
+    }
+  }
+
+  // Mix audio sources using Web Audio API
+  let audioContext: AudioContext | null = null
+  if (audioSources.length > 0) {
+    audioContext = new AudioContext()
+    const destination = audioContext.createMediaStreamDestination()
+
+    for (const source of audioSources) {
+      const sourceNode = audioContext.createMediaStreamSource(source)
+      sourceNode.connect(destination)
+    }
+
+    const mixedAudioTrack = destination.stream.getAudioTracks()[0]
+    if (mixedAudioTrack) {
+      tracks.push(mixedAudioTrack)
+    }
+  }
 
   const stream = new MediaStream(tracks)
   const recorder = new MediaRecorder(stream)
@@ -61,6 +91,28 @@ export async function startRecording(option: StartRecordingOption) {
       } catch {
         console.log('already stopped')
       }
+    }
+    // Stop original screen tracks
+    for (const track of screen.getTracks()) {
+      try {
+        track.stop()
+      } catch {
+        console.log('already stopped')
+      }
+    }
+    // Stop audio source streams
+    for (const source of audioSources) {
+      for (const track of source.getTracks()) {
+        try {
+          track.stop()
+        } catch {
+          console.log('already stopped')
+        }
+      }
+    }
+    // Close audio context
+    if (audioContext) {
+      await audioContext.close()
     }
     if (blobs.length === 0) {
       alert('too short! please try again')

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -2,6 +2,7 @@ export interface StartRecordingOption {
   enableMic: boolean
   enableAudio: boolean
   enableScreen: boolean
+  enableCamera: boolean
 }
 
 export async function startRecording(option: StartRecordingOption) {
@@ -13,10 +14,119 @@ export async function startRecording(option: StartRecordingOption) {
   const tracks: MediaStreamTrack[] = []
   const audioSources: MediaStream[] = []
 
-  // Collect video track
-  const videoTrack = screen.getVideoTracks()[0]
-  if (videoTrack) {
-    tracks.push(videoTrack)
+  // Get screen video track
+  const screenVideoTrack = screen.getVideoTracks()[0]
+  let cameraStream: MediaStream | null = null
+  let animationFrameId: number | null = null
+  let canvas: HTMLCanvasElement | null = null
+  let screenVideo: HTMLVideoElement | null = null
+  let cameraVideo: HTMLVideoElement | null = null
+
+  // Get camera stream if enabled
+  if (option.enableCamera) {
+    try {
+      cameraStream = await navigator.mediaDevices.getUserMedia({
+        video: { width: 320, height: 240 },
+      })
+    } catch (e) {
+      console.error('could not get camera: ', e)
+    }
+  }
+
+  // If camera is enabled and we have both streams, composite them
+  if (cameraStream && screenVideoTrack) {
+    const screenSettings = screenVideoTrack.getSettings()
+    const width = screenSettings.width || 1920
+    const height = screenSettings.height || 1080
+
+    // Create canvas for compositing
+    canvas = document.createElement('canvas')
+    canvas.width = width
+    canvas.height = height
+    const ctx = canvas.getContext('2d')!
+
+    // Create video elements for screen and camera
+    screenVideo = document.createElement('video')
+    screenVideo.srcObject = new MediaStream([screenVideoTrack])
+    screenVideo.muted = true
+    screenVideo.play()
+
+    cameraVideo = document.createElement('video')
+    cameraVideo.srcObject = cameraStream
+    cameraVideo.muted = true
+    cameraVideo.play()
+
+    // Camera overlay settings (bottom-left, circular)
+    const camSize = Math.min(width, height) * 0.2 // 20% of smaller dimension
+    const camMargin = 20
+    const camX = camMargin
+    const camY = height - camSize - camMargin
+
+    // Compositing loop
+    function drawFrame() {
+      if (!ctx || !screenVideo || !cameraVideo || !canvas) return
+
+      // Draw screen capture as background
+      ctx.drawImage(screenVideo, 0, 0, canvas.width, canvas.height)
+
+      // Draw camera as circular overlay in bottom-left
+      ctx.save()
+      ctx.beginPath()
+      ctx.arc(camX + camSize / 2, camY + camSize / 2, camSize / 2, 0, Math.PI * 2)
+      ctx.closePath()
+      ctx.clip()
+
+      // Draw camera video scaled to fit the circle
+      const camVideoWidth = cameraVideo.videoWidth || 320
+      const camVideoHeight = cameraVideo.videoHeight || 240
+      const camAspect = camVideoWidth / camVideoHeight
+      let drawWidth = camSize
+      let drawHeight = camSize
+      let offsetX = 0
+      let offsetY = 0
+
+      if (camAspect > 1) {
+        drawWidth = camSize * camAspect
+        offsetX = -(drawWidth - camSize) / 2
+      } else {
+        drawHeight = camSize / camAspect
+        offsetY = -(drawHeight - camSize) / 2
+      }
+
+      ctx.drawImage(cameraVideo, camX + offsetX, camY + offsetY, drawWidth, drawHeight)
+      ctx.restore()
+
+      // Draw circle border
+      ctx.beginPath()
+      ctx.arc(camX + camSize / 2, camY + camSize / 2, camSize / 2, 0, Math.PI * 2)
+      ctx.strokeStyle = 'white'
+      ctx.lineWidth = 3
+      ctx.stroke()
+
+      animationFrameId = requestAnimationFrame(drawFrame)
+    }
+
+    // Wait for videos to be ready
+    await Promise.all([
+      new Promise<void>((resolve) => {
+        screenVideo!.onloadedmetadata = () => resolve()
+      }),
+      new Promise<void>((resolve) => {
+        cameraVideo!.onloadedmetadata = () => resolve()
+      }),
+    ])
+
+    drawFrame()
+
+    // Capture canvas as video track
+    const canvasStream = canvas.captureStream(30)
+    const canvasVideoTrack = canvasStream.getVideoTracks()[0]
+    if (canvasVideoTrack) {
+      tracks.push(canvasVideoTrack)
+    }
+  } else if (screenVideoTrack) {
+    // No camera, just use screen video directly
+    tracks.push(screenVideoTrack)
   }
 
   // Collect tab/system audio
@@ -113,6 +223,20 @@ export async function startRecording(option: StartRecordingOption) {
     // Close audio context
     if (audioContext) {
       await audioContext.close()
+    }
+    // Stop camera stream
+    if (cameraStream) {
+      for (const track of cameraStream.getTracks()) {
+        try {
+          track.stop()
+        } catch {
+          console.log('already stopped')
+        }
+      }
+    }
+    // Cancel animation frame
+    if (animationFrameId) {
+      cancelAnimationFrame(animationFrameId)
     }
     if (blobs.length === 0) {
       alert('too short! please try again')


### PR DESCRIPTION
## Summary
- Mix browser tab audio with microphone using Web Audio API (previously only one audio source was recorded)
- Add webcam overlay feature (picture-in-picture) like Loom - circular overlay in bottom-left corner
- Add CLAUDE.md for Claude Code guidance

## Test plan
- [ ] Enable both mic and computer audio, verify both are recorded
- [ ] Enable camera option, verify circular webcam overlay appears in bottom-left
- [ ] Test recording without camera enabled works as before
- [ ] Test cleanup - verify camera light turns off after recording ends

🤖 Generated with [Claude Code](https://claude.ai/code)

<img width="1211" height="852" alt="image" src="https://github.com/user-attachments/assets/df4d115f-b02a-4ed8-b140-5002c7366c89" />

<img width="859" height="653" alt="image" src="https://github.com/user-attachments/assets/4694e047-a91a-47c9-a2de-b0890ba3d646" />

